### PR TITLE
Bluetooth: Prevent NPE in BluetoothInCallService

### DIFF
--- a/src/com/android/bluetooth/telephony/BluetoothInCallService.java
+++ b/src/com/android/bluetooth/telephony/BluetoothInCallService.java
@@ -315,8 +315,9 @@ public class BluetoothInCallService extends InCallService {
         if (bluetoothAdapter == null || !bluetoothAdapter.isEnabled()) {
             Log.i(TAG, "Bluetooth is off when unbind, disable BluetoothInCallService");
             AdapterService adapterService = AdapterService.getAdapterService();
-            adapterService.enableBluetoothInCallService(false);
-
+            if (adapterService != null) {
+                adapterService.enableBluetoothInCallService(false);
+            }
         }
         return super.onUnbind(intent);
     }


### PR DESCRIPTION
 * adapterService is null when BT is disabled by default

Change-Id: Ib73e16d94a6cddc3d857ef0cee7dfd02fae4faba